### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/govex/security/code-scanning/2](https://github.com/grokify/govex/security/code-scanning/2)

To fix this issue, add a `permissions` block specifying the minimum required permissions for the workflow. Since the workflow only needs to checkout code and does not need to write to the repository (no artifacts uploaded, no PR comments or issues manipulations), the minimal useful permissions are `contents: read`. The safest and cleanest way is to place `permissions: contents: read` at the top level of the workflow, immediately after the workflow name (before or after `on:`), so it applies to all jobs unless overridden. This change does not affect existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
