### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,7 @@
 name: lint
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   lint:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/govex/security/code-scanning/1](https://github.com/grokify/govex/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block to restrict permissions of the `GITHUB_TOKEN`. The recommended approach is to place the `permissions:` block at either the workflow level (before `jobs:`) to apply globally, or at the job level if only specific jobs need reduced or increased permissions. In this case, since there is only one job and no evidence of needing to write anywhere in the repository, set `permissions: contents: read` just before `jobs:`. You only need to add this YAML block above line 3 in the `.github/workflows/lint.yaml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
